### PR TITLE
Suport Python 3.6 and up

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,8 @@ classifiers =
     License :: OSI Approved :: ISC License (ISCL)
     Programming Language :: Python
     Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: Implementation :: CPython
@@ -24,10 +26,12 @@ classifiers =
 [options]
 install_requires =
     packaging
+    future-annotations; python_version < "3.10"
+    dataclasses; python_version < "3.7"
 packages = find:
 package_dir =
     = src
-python_requires = >=3.8
+python_requires = >=3.6
 
 [options.packages.find]
 where = src

--- a/src/packaging_dists/__init__.py
+++ b/src/packaging_dists/__init__.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+# -*- coding: future_annotations -*-
 
 import contextlib
 import dataclasses


### PR DESCRIPTION
This adds support for Python 3.6 and 3.7.

* Use @asottile future-annotations instead of __future___.annotations
  for all Pythons until 3.10
* Use dataclassses package for Python 3.6

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>