### PR TITLE
Add support for sdist with tar.bz2 extension

### DIFF
--- a/src/packaging_dists/__init__.py
+++ b/src/packaging_dists/__init__.py
@@ -56,7 +56,7 @@ def _split_ext(s: str, exts: Iterable[str]) -> Optional[Tuple[str, str]]:
 
 @dataclasses.dataclass()
 class Sdist:
-    extensions: ClassVar[List[str]] = [".tar.gz", ".zip"]
+    extensions: ClassVar[List[str]] = [".tar.gz", ".zip", ".tar.bz2"]
     project: str
     version: AnyVersion
 

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -56,6 +56,12 @@ from packaging_dists import Sdist, Wheel, parse
                 platform="win_amd64",
             ),
         ),
+        # tar.bz2 is a valid albeit legacy extension.
+        # See https://pypi.org/project/pyahocorasick/1.1.3/#files for instance
+        (
+            "pyahocorasick-1.1.3.tar.bz2",
+            Sdist(project="pyahocorasick", version=Version("1.1.3")),
+        ),
     ],
 )
 def test_parse(filename, expected):


### PR DESCRIPTION
tar.bz2 is a valid albeit legacy extension.

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>